### PR TITLE
Cut nova requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
-        "laravel/nova": "^2.0"
+        "php": ">=7.1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Causes issues with `composer require [this package]`.
Also semi-redundant, as nova is an implied requirement from the repo name.

Referencing #1 