### PR TITLE
Fix _.find() implementation

### DIFF
--- a/dist/js/field.js
+++ b/dist/js/field.js
@@ -10473,9 +10473,11 @@ function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, a
                                 formData.append('_method', 'PUT');
 
                                 return _context.abrupt('return', Nova.request().post('/nova-api/' + this.resourceName + '/' + this.resourceId, formData).then(function () {
-                                    var option = _.find(_this.field.options, ['value', _this.value]);
+                                    var label = _.find(_this.field.options, function (option) {
+                                        return option.value == _this.field.value;
+                                    }).label;
 
-                                    _this.$toasted.show('Status updated to "' + option.label + '"', { type: 'success' });
+                                    _this.$toasted.show('Status updated to "' + label + '"', { type: 'success' });
                                 }, function (response) {
                                     _this.$toasted.show(response, { type: 'error' });
                                 }).finally(function () {

--- a/resources/js/components/mixins/inline.js
+++ b/resources/js/components/mixins/inline.js
@@ -22,9 +22,9 @@ export default {
 
             return Nova.request().post(`/nova-api/${this.resourceName}/${this.resourceId}`, formData)
                 .then(() => {
-                    let option = _.find(this.field.options, ['value', this.value]);
-
-                    this.$toasted.show(`Status updated to "${option.label}"`, { type: 'success' });
+                    let label = _.find(this.field.options, { value: this.field.value }).label
+                    
+                    this.$toasted.show(`Status updated to "${label}"`, { type: 'success' });
                 }, (response) => {
                     this.$toasted.show(response, { type: 'error' });
                 })

--- a/resources/js/components/mixins/inline.js
+++ b/resources/js/components/mixins/inline.js
@@ -22,8 +22,8 @@ export default {
 
             return Nova.request().post(`/nova-api/${this.resourceName}/${this.resourceId}`, formData)
                 .then(() => {
-                    let label = _.find(this.field.options, { value: this.field.value }).label
-                    
+                    let label = _.find(this.field.options, option => option.value == this.field.value).label;
+
                     this.$toasted.show(`Status updated to "${label}"`, { type: 'success' });
                 }, (response) => {
                     this.$toasted.show(response, { type: 'error' });


### PR DESCRIPTION
This PR addresses https://github.com/kirschbaum-development/nova-inline-select/issues/11, the current broken implementation of the `_.find()` method used to query the field's value. 

I actually just stole the code from up above in the `displayValue()` computed value. :)